### PR TITLE
Assert ok should check for true or false

### DIFF
--- a/src/tests/apiHeroes.test.js
+++ b/src/tests/apiHeroes.test.js
@@ -33,7 +33,7 @@ describe('API Heroes test suite', function ()  {
         const statusCode = result.statusCode;
         const dados = JSON.parse(result.payload);
 
-        assert.ok(statusCode, 200);
+        assert.deepEqual(statusCode, 200);
         assert.ok(Array.isArray(dados));
     })
 
@@ -111,7 +111,7 @@ describe('API Heroes test suite', function ()  {
         const statusCode = result.statusCode
         const dados = JSON.parse(result.payload)
 
-        assert.ok(statusCode, 200)
+        assert.ok(statusCode === 200)
         assert.deepEqual(dados.message, 'Heroi atualizado com sucesso!')
     })
 
@@ -141,7 +141,7 @@ describe('API Heroes test suite', function ()  {
             method: 'DELETE',
             url: `/herois/${MOCK_ID}` 
         })
-        assert.ok(result.statusCode, 200) 
+        assert.ok(result.statusCode === 200) 
         assert.ok(JSON.parse(result.payload))
     })
 
@@ -176,7 +176,7 @@ describe('API Heroes test suite', function ()  {
             error: 'Internal Server Error',
             message: 'An internal server error occurred'
     }
-        assert.ok(statusCode, 500) 
-        assert.ok(dados, expected)
+        assert.ok(statusCode === 500) 
+        assert.deepEqual(dados, expected)
     })
 })


### PR DESCRIPTION
Quando você usa assert.ok, deve verificar se a condição é verdadeira. Está funcionando como você fez, porque está validando se o primeiro argumento existe. Como o statusCode não vem undefined, então funciona e não dá erro no teste, mas não está validando se o statusCode é 200. Quando você usa assert.ok, o segundo argumento é para colocar uma mensagem e não para comparar os dois valores. Quando quer comparar dois valores dessa forma, deve usar o deepEqual com compara os dois elementos.

Se for usar ok:
```assert.ok(statusCode === 200);```

Se for usar deepEqual:
```assert.deepEqual(statusCode, 200);```